### PR TITLE
Fix gemspec preventing `bundle install`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,3 +5,17 @@ require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec)
 task :default => :spec
 
+namespace(:spec) do
+  desc "Run all specs on multiple ruby versions (requires rvm)"
+  task(:portability) do
+    %w[1.8.6 1.8.7 1.9.2].each do |version|
+      system <<-BASH
+        bash -c 'source ~/.rvm/scripts/rvm;
+                 rvm #{version};
+                 echo "--------- version #{version} ----------\n";
+                 bundle install;
+                 rake spec'
+      BASH
+    end
+  end
+end

--- a/guard-compass.gemspec
+++ b/guard-compass.gemspec
@@ -1,10 +1,10 @@
 # -*- encoding: utf-8 -*-
 $:.push File.expand_path('../lib', __FILE__)
-require 'guard/compass'
+require 'guard/compass/version'
 
 Gem::Specification.new do |s|
   s.name        = 'guard-compass'
-  s.version     = Guard::Compass::VERSION
+  s.version     = Guard::CompassVersion::VERSION
   s.platform    = Gem::Platform::RUBY
   s.authors     = ['Olivier Amblet']
   s.email       = ['olivier@amblet.net']

--- a/lib/guard/compass.rb
+++ b/lib/guard/compass.rb
@@ -9,8 +9,6 @@ module Guard
   class Compass < Guard
     attr_reader :updater
     
-    VERSION = '0.0.6'
-    
     def initialize(watchers = [], options = {})
       super
       @options[:workdir] = File.expand_path(File.dirname("."))

--- a/lib/guard/compass/version.rb
+++ b/lib/guard/compass/version.rb
@@ -1,0 +1,5 @@
+module Guard
+  module CompassVersion
+    VERSION = '0.0.6'
+  end
+end


### PR DESCRIPTION
Fix gemspec that was requiring guard/compass, which was requiring guard and compass, before anything else! So without guard and compass already installed on the machine, it was impossible to `bundle install`.
Originally reported here: https://github.com/guard/guard/issues/#issue/22
