### PR TITLE
Allow users to compile stylesheets when Guard is started

### DIFF
--- a/lib/guard/compass.rb
+++ b/lib/guard/compass.rb
@@ -64,7 +64,12 @@ module Guard
     # Compile all the sass|scss stylesheets
     def start
       create_updater
-      reporter.announce "Guard::Compass is waiting to compile your stylesheets."
+      if (options[:compile_on_start])
+        reporter.announce "Guard::Compass is going to compile your stylesheets."
+        perform
+      else
+        reporter.announce "Guard::Compass is waiting to compile your stylesheets."
+      end
       true
     end
 


### PR DESCRIPTION
Not sure if this was already possible, but this pull request allows users to specify the following in their `Guardfile`:

``` ruby
guard 'compass', :compile_on_start => true do
  watch(%r{scss/(.*).scss})
end
```

This appears to be useful if multiple people are working on a Compass project and don't check in compiled stylesheets to the repository.  From what I could tell compass won't immediately create new *.css files until one of the sass files has changed.

Hope you find this useful, thanks for the great plugin!
