### PR TITLE
add support for additional_import_paths and add_import_path

### DIFF
--- a/lib/guard/compass.rb
+++ b/lib/guard/compass.rb
@@ -44,6 +44,10 @@ module Guard
 
       watchers.push Watcher.new(%r{^#{src_path.relative_path_from(working_path)}/.*})
       watchers.push Watcher.new(%r{^#{config_path.relative_path_from(working_path)}$})
+
+      Array(::Compass.configuration.additional_import_paths).each do |additional_path|
+        watchers.push Watcher.new(%r{^#{pathname(additional_path).relative_path_from(working_path)}/.*})
+      end
     end
 
     def root_path

--- a/spec/fixtures/additional_import_paths/additional_src_location_1/print.scss
+++ b/spec/fixtures/additional_import_paths/additional_src_location_1/print.scss
@@ -1,0 +1,3 @@
+/* Welcome to Compass. Use this file to define print styles.
+ * Import this file using the following HTML or equivalent:
+ * <link href="/stylesheets/print.css" media="print" rel="stylesheet" type="text/css" /> */

--- a/spec/fixtures/additional_import_paths/additional_src_location_2/ie.scss
+++ b/spec/fixtures/additional_import_paths/additional_src_location_2/ie.scss
@@ -1,0 +1,5 @@
+/* Welcome to Compass. Use this file to write IE specific override styles.
+ * Import this file using the following HTML or equivalent:
+ * <!--[if IE]>
+ *   <link href="/stylesheets/ie.css" media="screen, projection" rel="stylesheet" type="text/css" />
+ * <![endif]--> */

--- a/spec/fixtures/additional_import_paths/another_config_location/config.rb
+++ b/spec/fixtures/additional_import_paths/another_config_location/config.rb
@@ -1,0 +1,12 @@
+# Require any additional compass plugins here.
+# Set this to the root of your project when deployed:
+http_path = "/"
+css_dir = "another_stylesheets_location"
+sass_dir = "another_src_location"
+images_dir = "another_images_location"
+javascripts_dir = "another_javascripts_location"
+# To enable relative paths to assets via compass helper functions. Uncomment:
+# relative_assets = true
+
+additional_import_paths = ["another_src_location_1"]
+add_import_path "another_src_location_2"

--- a/spec/fixtures/additional_import_paths/another_src_location/screen.scss
+++ b/spec/fixtures/additional_import_paths/another_src_location/screen.scss
@@ -1,0 +1,6 @@
+/* Welcome to Compass.
+ * In this file you should write your main styles. (or centralize your imports)
+ * Import this file using the following HTML or equivalent:
+ * <link href="/stylesheets/screen.css" media="screen, projection" rel="stylesheet" type="text/css" /> */
+
+@import "compass/reset";

--- a/spec/guard/compass_spec.rb
+++ b/spec/guard/compass_spec.rb
@@ -271,6 +271,35 @@ describe Guard::Compass do
         @guard.watchers.first.pattern.should eq(%r{^another_src_location/.*}), ::Compass.configuration.sass_dir
       end
     end
+
+    describe "with additional_import_paths" do
+      before do
+        create_fixture :additional_import_paths
+        @guard = Guard::Compass.new(project_path: ".", configuration_file: 'another_config_location/config.rb')
+      end
+
+      after do
+        remove_fixtures
+        ::Compass.reset_configuration!
+      end
+
+      it "should have some watchers" do
+        @guard.reporter.should_not_receive(:failure)
+        @guard.options[:project_path].should eq "."
+        @guard.options[:configuration_file].should eq 'another_config_location/config.rb'
+
+        @guard.start
+
+        @guard.options[:project_path].should eq "."
+        @guard.options[:configuration_file].should eq "#{@project_path}/another_config_location/config.rb"
+
+        @guard.watchers.size.should eq(4), @guard.watchers.inspect
+        @guard.watchers[0].pattern.should eq(%r{^another_src_location/.*}), ::Compass.configuration.sass_dir
+        @guard.watchers[1].pattern.should eq %r{^another_config_location/config.rb$}
+        @guard.watchers[2].pattern.should eq %r{^another_src_location_1/.*}
+        @guard.watchers[3].pattern.should eq %r{^another_src_location_2/.*}
+      end
+    end
   end
 end
 


### PR DESCRIPTION
These are available in the [compass configuration file](http://compass-style.org/help/tutorials/configuration-reference/).

I've added support for using these to create additional watchers to provide parity (in this regard at least) with `$ compass watch` .

`additional_import_paths` is an array of paths (as strings) and `add_import_path` is a method to append a path (as a sting) to this array so they are both supported by enumerating `::Compass.configuration.additional_import_paths` 
