### PR TITLE
change travis rbx to latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
   - 1.9.3
   - 2.0.0
   - jruby-19mode
-  - rbx-19mode
+  - rbx
 notifications:
   recipients:
     - remy@rymai.me


### PR DESCRIPTION
per #26 `rbx-19mode` is no longer supported on travis.
https://travis-ci.org/guard/guard-compass/jobs/20257272

http://docs.travis-ci.com/user/languages/ruby/#Rubinius

This changes travis to use the latest version.
